### PR TITLE
Introduced ability to transfer issues from private to public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It also has the ability to do the following:
   ```
 
 * Apply labels to the transffered issue.
+* Create labels in the destination repository if they are missing.
 
 ## Events
 
@@ -25,6 +26,32 @@ on:
       - labeled
 ```
 
+## Transferring from Private to Public repositories
+
+Transferring issues from private to public repositories is not supported by GitHub by default ([see related post here](https://github.com/orgs/community/discussions/21979#discussioncomment-4800558)).
+
+Nevertheless the community has found a way to go around that limitation, process that can be entirely automated.
+
+When `allow_private_public_transfer` is enabled, and if a request is made to transfer to an issue from a private repository to a public one, a temporary private repository will be automatically created, the issue will be transferred to that repository which will then be made public. Finally after the transfer, the repository will be deleted.
+
+This manipulation requires your Personal API Token to have the `delete_repo` scope. 
+
+The name of that temporary repository is composed of a stringified date to which a random 5 characters string is appended. 
+
+This option is disabled by default.
+
+## Route to any repository based on the label
+
+This action can be used to route an issue to a pre-set repository, but also, if enabled, to any repository of the organization.
+
+By enabling `enable_custom_label_routing`, users can transfer their issue to any repository by attaching a label such as `transfer:my-other-repo`. 
+
+This option is to be used in conjunction with the `router` option, by the repository part of the router empty.
+
+When `router` is set to `transfer:` and if the user creates a label such as `transfer:my-other-repo`, the issue will be automatically transferred to the `my-other-repo` repository.
+
+This option is disabled by default.
+
 ## Inputs
 
 Input | Description | Required | Default |
@@ -33,6 +60,10 @@ Input | Description | Required | Default |
 | `router` | A label to repo routing in the form "LABEL:REPO" | yes* |-|
 | `apply_label` | A label to apply on the new issue in the format "LABEL:HEXCODE" | yes* |-|
 | `create_stub` | Create a stub issue with title and description in original repo | no | `false` |
+| `debug` | Enable debug output | no | `false` |
+| `allow_private_public_transfer` | Allow issues to be transferred from private to public repositories. | no | `false` |
+| `enable_custom_label_routing` | Make it possible to route labels to any repository of the organization by providing the repository name in the label name | no | `false` |
+| `create_labels_if_missing` | Create labels in the destination repository if missing | no | `false` |
 | `debug` | Enable debug output | no | `false` |
 
 ### Input Notes

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,15 @@ inputs:
   create_stub:
     description: Create a stub issue with title and description in original repo
     default: false
+  allow_private_public_transfer:
+    description: Do we allow transferring a private issue to a public repo
+    default: false    
+  create_labels_if_missing:
+    description: Whether to create labels if they don't exist in the target repository (matched by name)
+    default: false
+  enable_custom_label_routing:
+    description:  Make it possible to route labels to any repository of the organization by providing the repository name in the label name
+    default: false    
   debug:
     description: Enable debug output
     default: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,28 @@ const crypto = require('crypto');
 const {context, getOctokit} = require('@actions/github');
 const debug = require('debug')('@lando/transfer-issue-action');
 
+// From: https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
+const salt = (length) => {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}
+// Generate a new repository name using DATE-salt
+const getRepoName = () => {
+  return `${
+    new Date()
+      .toISOString()
+      .replace(/[^a-z0-9+]+/gi, '')
+      .toLowerCase()
+    }-${salt(5)}`
+}
+
 async function run() {
   try {
     // Enable debugging if appropriate
@@ -25,6 +47,7 @@ async function run() {
     const sourceIssue = context.payload.issue || {node_id: testIssueId, user: {login: sourceRepo.owner.login}};
     const sourceLabel = context.payload.label || {name: testLabelName};
     const token = core.getInput('token', {required: true});
+    const enableCustomLabelRouting = core.getInput('enable_custom_label_routing', {required: false}) === 'true';
 
     // Throw errors if we cannot continue
     if (sourceIssue === undefined) {
@@ -53,16 +76,26 @@ async function run() {
 
     // Summon the octocat
     const octokit = getOctokit(token);
+
     // Split router up into relevant pieces
     // @NOTE: this is not documented but if there is no splitter then the string will
     // be interpretted as the destination repo
-    const parts = router.split(':');
-    const targetRepoName = parts[1] || parts[0];
+    const parts = router.split(':');    
+    let targetRepoName = parts[1] || parts[0];
     const triggerLabel = parts[0];
-    debug('will transfer issue to %s if %s matches %s', targetRepoName, triggerLabel, sourceLabel.name);
+    if (enableCustomLabelRouting === true) {
+      core.info(`Custom routing enabled, received label: ${sourceLabel.name}`);
+      const [ labelRouter, targetRepo ] = sourceLabel.name.split(':')
+      // If the configured router is equal to the first part of the label
+      // i.e router === 'transfer:' and the issue label === 'transfer:my-new-repo'
+      if (targetRepo !== undefined && targetRepo !== '' && labelRouter !== undefined && labelRouter === triggerLabel) {
+        targetRepoName = targetRepo
+      }
+    } 
+    core.info(`Will transfer issue to ${targetRepoName} if ${triggerLabel} matches ${sourceLabel.name}`);
 
     // If trigger label doesnt match the issue label then bail
-    if (triggerLabel && triggerLabel !== sourceLabel.name) {
+    if (enableCustomLabelRouting === false && triggerLabel && triggerLabel !== sourceLabel.name) {
       return core.notice(`Issue not transferred because "${sourceLabel.name}" != "${triggerLabel}"!`);
     }
 
@@ -84,20 +117,122 @@ async function run() {
     });
     debug('retrieved target repo metadata %O', targetRepo.data);
 
-    // Our GraphQL Transfer Mutation.
-    const transfer = await octokit.graphql(`
-      mutation {
-          transferIssue(input: {
-            clientMutationId: "${crypto.randomBytes(20).toString('hex')}",
-            repositoryId: "${targetRepo.data.node_id}",
-            issueId: "${sourceIssue.node_id}"
-          }) {
-            issue {
-              number
+    // Create placeholder transfer object
+    let transfer = {} 
+
+    // Check if we're trying to copy to from a private to a public repo
+    // Transfering from a private repo to a public one if very tedious
+    // as it involves creating a temporary repo and making it public
+    // Using this workaround: https://github.com/orgs/community/discussions/21979#discussioncomment-4800558
+    // The algorithm is as follow:
+    // 1 - Create a new private repo
+    // 2 - Transfer the issue to that repository
+    // 3 - Make the repository public
+    // 4 - Transfer the issue to the original destination
+    // 5 - Delete the original repository    
+    if (core.getInput('allow_private_public_transfer') === 'true') {
+      core.info(`Source repository ${sourceRepo.name} is ${sourceRepo.private === true ? 'private' : 'public'}`);
+      core.info(`Destination repository ${targetRepo.data.name} is ${targetRepo.data.private === true ? 'private' : 'public'}`);      
+      if (sourceRepo.private === true && targetRepo.data.private === false) {
+        core.info(`Issue transfer from private to public repository requires the creation of a temporary repository`);
+        const tempRepoName = getRepoName()
+        core.info(`Creating a temporary repository with name: ${tempRepoName}`);
+        const tempRepo = await octokit.request('POST /orgs/{org}/repos', {
+          org: sourceRepo.owner.login,
+          name: tempRepoName,
+          description: 'Temporary repository created to transfer an issue',
+          'private': true,
+          has_issues: true,
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        })
+        core.info(`New repository created at: ${tempRepo.data.html_url}`);
+
+
+        core.info(`Transferring the issue to: ${tempRepoName}`);
+        const transferIssueToTmpRepo = await octokit.graphql(`
+          mutation {
+              transferIssue(input: {
+                clientMutationId: "${crypto.randomBytes(20).toString('hex')}",
+                repositoryId: "${tempRepo.data.node_id}",
+                createLabelsIfMissing: ${core.getInput('create_labels_if_missing') === 'true'},
+                issueId: "${sourceIssue.node_id}"
+              }) {
+                issue {
+                  number
+                  id
+                  url
+                }
+              }
+            }
+        `);
+        core.info(`Issue transferred to: ${transferIssueToTmpRepo.transferIssue.issue.url}`);
+        const tmpNewIssueNumber = transferIssueToTmpRepo.transferIssue.issue.number;
+        debug('Transferred %s:%s to target %s:%s', sourceRepo.name, sourceIssue.node_id, tempRepo.name, tmpNewIssueNumber);
+
+        core.info(`Changing repository visibility to public`);
+        const tempRepoPublic = await octokit.request('PATCH /repos/{org}/{repo}', {
+          org: sourceRepo.owner.login,
+          repo: tempRepoName,
+          'private': false,
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        })
+        core.info(`Repository status is now: ${tempRepoPublic.data.visibility}`);
+        
+
+        core.info(`Transferring issue to public repository`);
+        transfer = await octokit.graphql(`
+          mutation {
+              transferIssue(input: {
+                clientMutationId: "${crypto.randomBytes(20).toString('hex')}",
+                repositoryId: "${targetRepo.data.node_id}",
+                createLabelsIfMissing: ${core.getInput('create_labels_if_missing') === 'true'},
+                issueId: "${ transferIssueToTmpRepo.transferIssue.issue.id}"
+              }) {
+                issue {
+                  number
+                  url
+                }
+              }
+            }
+        `);
+        core.info(`Issue transferred to: ${transfer.transferIssue.issue.url}`);
+
+        core.info(`Deleting temporary repository: ${tempRepoName}`);
+        const tempRepoDelete = await octokit.request('DELETE /repos/{owner}/{repo}', {
+          owner: sourceRepo.owner.login,
+          repo: tempRepoName,
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        })
+        core.info(`Repository: ${tempRepoName} deleted`);
+
+      } else {
+        core.info(`Issue transfer is possible without creating intermediary repository!`);
+      }
+    } else {
+      // Our GraphQL Transfer Mutation.
+      // Inputs are actually converted to strings, thus the need for the condition.
+      transfer = await octokit.graphql(`
+        mutation {
+            transferIssue(input: {
+              clientMutationId: "${crypto.randomBytes(20).toString('hex')}",
+              repositoryId: "${targetRepo.data.node_id}",
+              createLabelsIfMissing: ${core.getInput('create_labels_if_missing') === 'true'},
+              issueId: "${sourceIssue.node_id}"
+            }) {
+              issue {
+                number
+              }
             }
           }
-        }
-    `);
+      `);
+    }
+
     const newIssueNumber = transfer.transferIssue.issue.number;
     const newIssueUrl = `https://github.com/${sourceRepo.owner.login}/${targetRepoName}/issues/${newIssueNumber}`;
 


### PR DESCRIPTION
Hello,

Thanks for the original work on the action.

This PR provides three new features I needed for my own workflows:

- Ability to create labels in the destination repository if missing (based on an available parameter in GitHub GraphQL API)
- Ability to transfer issues based on label names, and not only the destination defined in the router (for example attaching the label `transfer:my-new-repo` transfers the issue to `my-new-repo`if it exists.
- Ability to transfer issues from private repositories to public repositories.

That later one is a bit cumbersome as it involves creating a temporary repository, but it seems aligned with a suggested workaround found [in various places](https://github.com/orgs/community/discussions/21979#discussioncomment-4800558).

I included documentation on how to use these features.

In the suggested PR, all these features are disabled by default. I tested them in my repositories (manual tests, no automated tests)

I understand this PR contains quite a bit of change and the implementation for moving issues from private to public is debatable.