### PR TITLE
Bump @octokit/plugin-paginate-rest and @actions/github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -635,9 +635,9 @@
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
-      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"


### PR DESCRIPTION
Replacement for #99 after branch restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch dependency update with no changes to action logic or direct dependency version ranges.
> 
> **Overview**
> Updates the lockfile so **`@octokit/plugin-paginate-rest`** moves from **9.2.1** to **9.2.2** (patch release). This is a transitive dependency of **`@actions/github`**, which the action uses for GitHub API access; **no application source changes** are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4483cd7dc9cf7e965705fffb35a5d42219d4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->