### PR TITLE
Bump @octokit/request and @actions/github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,13 +695,13 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.1",
-        "@octokit/request-error": "^5.1.0",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },


### PR DESCRIPTION
Replacement for #100 after branch restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency update with no source changes; typical low-risk maintenance.
> 
> **Overview**
> Updates **`package-lock.json`** so the transitive **`@octokit/request`** dependency moves from **8.4.0** to **8.4.1**, with aligned bumps to **`@octokit/endpoint`** (^9.0.6) and **`@octokit/request-error`** (^5.1.1) in that package’s dependency tree.
> 
> **`package.json`** is unchanged; **`@actions/github`** remains at **^6.0.0**. This is a lockfile-only refresh (replacement for prior Dependabot work on the same bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d13690eaa92fd5c5562ab597fe22a67cebd026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->